### PR TITLE
Fix missing templates in PyPI distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,8 @@ build
 __pycache__
 *.pyc
 src/out
-wifizone
 src/sideseeing_tools/templates_old
 src/tmp
 .tox
 .idea
+ignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ src/tmp
 .tox
 .idea
 ignore
+dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ python_files = ["test_*.py",]
 
 [tool.setuptools.package-data]
 "tests" = ["*"]
+"sideseeing_tools" = ["templates/**/*"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
Currently, installing sideseeing-tools via pip (from PyPI) does not include the templates/ directory. This causes a TemplateNotFound: report.html error when calling export.Report(). This PR updates pyproject.toml to explicitly include the templates directory and all its contents (including the static folder) in the package distribution.

I verified by running python -m build and confirming that the templates folder is present in the resulting wheel and source distribution.